### PR TITLE
Disable default Bevy features for wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.11", features = ["dynamic_linking"] }
+bevy = { version = "0.11", default-features = false, features = ["bevy_winit", "webgl2"] }
 rand = "0.8"


### PR DESCRIPTION
## Summary
- disable Bevy default features and enable `bevy_winit` + `webgl2`

## Testing
- `cargo build --target wasm32-unknown-unknown` *(fails: failed to select a version for `web-sys` with `GpuImageCopyBuffer`)*

------
https://chatgpt.com/codex/tasks/task_e_68b345b3d5648326995b4b8944fce5b7