### PR TITLE
refactor: drop webgl2 from bevy deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.11", default-features = false, features = ["bevy_winit", "webgl2"] }
+bevy = { version = "0.11", default-features = false, features = ["bevy_winit"] }
 rand = "0.8"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+bevy = { version = "0.11", default-features = false, features = ["webgl2"] }


### PR DESCRIPTION
## Summary
- remove `webgl2` from the default `bevy` feature set
- add target-specific `bevy` dependency enabling `webgl2` only for wasm

## Testing
- `cargo build --locked` *(fails: package `wgpu` depends on `web-sys` with feature `GpuImageCopyBuffer` but `web-sys` does not have that feature)*

------
https://chatgpt.com/codex/tasks/task_e_68b3485bfb048326b3230829557a2a84