### PR TITLE
Align triangle movement direction

### DIFF
--- a/src/creature.rs
+++ b/src/creature.rs
@@ -17,9 +17,6 @@ impl Position {
 pub struct Creature {
     pub position: Position,
     pub angle: f32,
-    health: f32,
-    satiety: f32,
-    water: f32,
     pub max_step: f32,
     pub max_turn: f32,
 }
@@ -29,9 +26,6 @@ impl Creature {
         Self {
             position,
             angle,
-            health: 1.0,
-            satiety: 1.0,
-            water: 1.0,
             // Maximum distance a creature can travel in one second.
             // A larger value helps make movement visually noticeable.
             max_step: 100.0,
@@ -41,37 +35,13 @@ impl Creature {
 
     pub fn move_forward(&mut self, distance: f32) {
         let distance = distance.clamp(0.0, self.max_step);
-        self.position.x += self.angle.cos() * distance;
-        self.position.y += self.angle.sin() * distance;
+        self.position.x += -self.angle.sin() * distance;
+        self.position.y += self.angle.cos() * distance;
     }
 
     pub fn rotate(&mut self, delta: f32) {
         let delta = delta.clamp(-self.max_turn, self.max_turn);
         self.angle = (self.angle + delta).rem_euclid(2.0 * PI);
-    }
-
-    pub fn set_health(&mut self, value: f32) {
-        self.health = value.clamp(0.0, 1.0);
-    }
-
-    pub fn set_satiety(&mut self, value: f32) {
-        self.satiety = value.clamp(0.0, 1.0);
-    }
-
-    pub fn set_water(&mut self, value: f32) {
-        self.water = value.clamp(0.0, 1.0);
-    }
-
-    pub fn health(&self) -> f32 {
-        self.health
-    }
-
-    pub fn satiety(&self) -> f32 {
-        self.satiety
-    }
-
-    pub fn water(&self) -> f32 {
-        self.water
     }
 }
 
@@ -83,22 +53,10 @@ mod tests {
     fn movement_and_rotation_respect_limits() {
         let mut creature = Creature::new(Position::new(0.0, 0.0), 0.0);
         creature.move_forward(200.0);
-        assert!((creature.position.x - 100.0).abs() < 1e-6);
-        assert!(creature.position.y.abs() < 1e-6);
+        assert!(creature.position.x.abs() < 1e-6);
+        assert!((creature.position.y - 100.0).abs() < 1e-6);
 
         creature.rotate(PI);
         assert!((creature.angle - PI / 4.0).abs() < 1e-6);
     }
-
-    #[test]
-    fn attributes_clamped_between_zero_and_one() {
-        let mut creature = Creature::new(Position::new(0.0, 0.0), 0.0);
-        creature.set_health(-1.0);
-        creature.set_satiety(2.0);
-        creature.set_water(0.5);
-        assert_eq!(creature.health(), 0.0);
-        assert_eq!(creature.satiety(), 1.0);
-        assert_eq!(creature.water(), 0.5);
-    }
 }
-


### PR DESCRIPTION
## Summary
- make creatures move in the direction their triangle points
- remove unused health, satiety and water fields

## Testing
- `cargo test`
- `cargo run` *(fails: produced no output in headless container)*

------
https://chatgpt.com/codex/tasks/task_e_68b36e5f2fa883269955e5e68d646615