### PR TITLE
Use embedded font for FPS display and boost rotation speed

### DIFF
--- a/src/creature.rs
+++ b/src/creature.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use std::f32::consts::PI;
+use std::f32::consts::{PI, TAU};
 
 #[derive(Component, Debug, Clone, Copy)]
 pub struct Position {
@@ -29,7 +29,7 @@ impl Creature {
             // Maximum distance a creature can travel in one second.
             // A larger value helps make movement visually noticeable.
             max_step: 100.0,
-            max_turn: PI / 4.0,
+            max_turn: TAU,
         }
     }
 
@@ -56,7 +56,7 @@ mod tests {
         assert!(creature.position.x.abs() < 1e-6);
         assert!((creature.position.y - 100.0).abs() < 1e-6);
 
-        creature.rotate(PI);
-        assert!((creature.angle - PI / 4.0).abs() < 1e-6);
+        creature.rotate(10.0 * TAU);
+        assert!(creature.angle.abs() < 1e-6);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn setup(
     }
 
     let text_style = TextStyle {
-        font: default(),
+        font: bevy::text::DEFAULT_FONT_HANDLE.typed(),
         font_size: 20.0,
         color: Color::WHITE,
     };


### PR DESCRIPTION
## Summary
- Display stats text using Bevy's built-in default font instead of bundling a binary font asset
- Allow creatures to turn quickly by increasing their maximum rotation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b37500d4c48326811099d8763a2de1